### PR TITLE
Rename project to Basketball Drop

### DIFF
--- a/Basketball Drop.yyp
+++ b/Basketball Drop.yyp
@@ -1,6 +1,6 @@
 {
   "$GMProject":"v1",
-  "%Name":"Menu",
+  "%Name":"Basketball Drop",
   "AudioGroups":[
     {"$GMAudioGroup":"","%Name":"audiogroup_default","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
   ],
@@ -38,7 +38,7 @@
   "MetaData":{
     "IDEVersion":"2024.13.1.193",
   },
-  "name":"Menu",
+  "name":"Basketball Drop",
   "resources":[
     {"id":{"name":"obj_ball","path":"objects/obj_ball/obj_ball.yy",},},
     {"id":{"name":"obj_controller","path":"objects/obj_controller/obj_controller.yy",},},

--- a/options/android/options_android.yy
+++ b/options/android/options_android.yy
@@ -11,7 +11,7 @@
   "option_android_compile_sdk":"",
   "option_android_device_support":0,
   "option_android_display_layout":"",
-  "option_android_display_name":"Menu",
+  "option_android_display_name":"Basketball Drop",
   "option_android_edge_to_edge_display":false,
   "option_android_facebook_app_display_name":"",
   "option_android_facebook_id":"",

--- a/options/html5/options_html5.yy
+++ b/options/html5/options_html5.yy
@@ -3,7 +3,7 @@
   "%Name":"HTML5",
   "name":"HTML5",
   "option_html5_allow_fullscreen":true,
-  "option_html5_browser_title":"Menu",
+  "option_html5_browser_title":"Basketball Drop",
   "option_html5_centregame":false,
   "option_html5_display_cursor":true,
   "option_html5_facebook_app_display_name":"",

--- a/options/ios/options_ios.yy
+++ b/options/ios/options_ios.yy
@@ -6,7 +6,7 @@
   "option_ios_bundle_name":"com.company.game",
   "option_ios_defer_home_indicator":false,
   "option_ios_devices":2,
-  "option_ios_display_name":"Menu",
+  "option_ios_display_name":"Basketball Drop",
   "option_ios_enable_broadcast":false,
   "option_ios_half_ipad1_textures":false,
   "option_ios_icon_ipad_app_152":"${base_options_dir}/ios/icons/app/ipad_152.png",

--- a/options/linux/options_linux.yy
+++ b/options/linux/options_linux.yy
@@ -5,7 +5,7 @@
   "option_linux_allow_fullscreen":false,
   "option_linux_disable_sandbox":false,
   "option_linux_display_cursor":true,
-  "option_linux_display_name":"Menu",
+  "option_linux_display_name":"Basketball Drop",
   "option_linux_display_splash":false,
   "option_linux_enable_steam":false,
   "option_linux_homepage":"http://www.yoyogames.com",

--- a/options/mac/options_mac.yy
+++ b/options/mac/options_mac.yy
@@ -14,7 +14,7 @@
   "option_mac_copyright":"",
   "option_mac_disable_sandbox":false,
   "option_mac_display_cursor":true,
-  "option_mac_display_name":"Menu",
+  "option_mac_display_name":"Basketball Drop",
   "option_mac_enable_retina":false,
   "option_mac_enable_steam":false,
   "option_mac_icon_png":"${base_options_dir}/mac/icons/1024.png",

--- a/options/tvos/options_tvos.yy
+++ b/options/tvos/options_tvos.yy
@@ -5,7 +5,7 @@
   "option_tvos_build_number":0,
   "option_tvos_bundle_name":"com.company.game",
   "option_tvos_display_cursor":false,
-  "option_tvos_display_name":"Menu",
+  "option_tvos_display_name":"Basketball Drop",
   "option_tvos_enable_broadcast":false,
   "option_tvos_icon_1280":"${base_options_dir}/tvos/icons/1280.png",
   "option_tvos_icon_400":"${base_options_dir}/tvos/icons/400.png",

--- a/options/windows/options_windows.yy
+++ b/options/windows/options_windows.yy
@@ -10,7 +10,7 @@
   "option_windows_description_info":"A GameMaker Game",
   "option_windows_disable_sandbox":false,
   "option_windows_display_cursor":true,
-  "option_windows_display_name":"Menu",
+  "option_windows_display_name":"Basketball Drop",
   "option_windows_enable_steam":false,
   "option_windows_executable_name":"${project_name}.exe",
   "option_windows_icon":"${base_options_dir}/windows/icons/icon.ico",

--- a/sprites/Sprite10/Sprite10.yy
+++ b/sprites/Sprite10/Sprite10.yy
@@ -25,8 +25,8 @@
   "nineSlice":null,
   "origin":0,
   "parent":{
-    "name":"Menu",
-    "path":"Menu.yyp",
+    "name":"Basketball Drop",
+    "path":"Basketball Drop.yyp",
   },
   "preMultiplyAlpha":false,
   "resourceType":"GMSprite",


### PR DESCRIPTION
## Summary
- rename GameMaker project metadata from "Menu" to "Basketball Drop"
- update platform display names and browser title to reflect new name
- fix sprite parent reference to use the new project file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e94feb3483228c9fa8d79774f129