### PR TITLE
Add room transition after goal

### DIFF
--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -5,3 +5,9 @@ var music_enabled = variable_struct_get(controller.settings, "music_enabled");
 if (sfx_enabled) {
     audio_play_sound(phaser, 10, false);
 }
+
+if (room_next(room) != -1) {
+    room_goto_next();
+} else {
+    room_goto(rm_main_menu);
+}


### PR DESCRIPTION
## Summary
- After scoring, move to the next room or fall back to the main menu

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e9b6b5483229d15d00f4e7b6cc5