### PR TITLE
Add global flag to control ball spawning

### DIFF
--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -6,6 +6,7 @@ if (sfx_enabled) {
     audio_play_sound(phaser, 10, false);
 }
 
+global.can_spawn_ball = false;
 if (room_next(room) != -1) {
     room_goto_next();
 } else {

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -35,4 +35,9 @@ settings = {
 // ————————————————
 autosave_timer = 0;
 
+// Flag controlling whether balls can be spawned
+global.can_spawn_ball = false;
+
+// Track the current room to detect transitions
+last_room = room;
 

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -1,5 +1,11 @@
 /// obj_controller – Step Event
 
+// Reset spawn permission on room changes
+if (room != last_room) {
+    global.can_spawn_ball = (room != rm_main_menu && room != rm_options);
+    last_room = room;
+}
+
 // Advance timer (seconds)
 autosave_timer += delta_time / 1_000_000;
 

--- a/objects/obj_gamepad/Step_0.gml
+++ b/objects/obj_gamepad/Step_0.gml
@@ -1,6 +1,4 @@
-if (mouse_check_button(mb_left) && (alarm[0] < 0)) {
-    if (room != rm_main_menu && room != rm_options) {
-        instance_create_layer(mouse_x, mouse_y, layer, obj_ball);
-        alarm[0] = 5;
-    }
+if (global.can_spawn_ball && mouse_check_button(mb_left) && alarm[0] < 0) {
+    instance_create_layer(mouse_x, mouse_y, layer, obj_ball);
+    alarm[0] = 5;
 }

--- a/objects/obj_room_button/Step_0.gml
+++ b/objects/obj_room_button/Step_0.gml
@@ -8,6 +8,7 @@ hover = (mx >= x && mx <= x + width && my >= y && my <= y + height);
 
 // On click, change room
 if (hover && mouse_check_button_pressed(mb_left)) {
+    global.can_spawn_ball = false;
     if (room_exists(target_room)) {
         room_goto(target_room);
     }

--- a/objects/obj_toggle_button/Step_0.gml
+++ b/objects/obj_toggle_button/Step_0.gml
@@ -7,9 +7,9 @@ var my = device_mouse_y(0);
 hover = point_in_rectangle(mx, my, x, y, x + width, y + height);
 
 if (hover && mouse_check_button_pressed(mb_left)) {
-    
-   
-		var controller = global.controller;
+    global.can_spawn_ball = false;
+
+                var controller = global.controller;
         var current = variable_struct_get(controller.settings, toggle_key);
         var flipped = !current;
         variable_struct_set(controller.settings, toggle_key, flipped);


### PR DESCRIPTION
## Summary
- Add global.can_spawn_ball flag in controller and track room changes
- Gate gamepad ball creation and disable flag during UI clicks or room transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae20ec8d508322b18cfe88a988bcd8