### PR TITLE
Add par tracking and persistent attempt history

### DIFF
--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -7,8 +7,29 @@ if (sfx_enabled) {
 }
 
 global.can_spawn_ball = false;
+array_push(global.hole_scores, global.strokes);
+global.running_total += global.strokes;
+var delta = global.strokes - global.current_par;
+if (delta <= -2) {
+    global.classification = (delta <= -3) ? "Albatross" : "Eagle";
+} else if (delta == -1) {
+    global.classification = "Birdie";
+} else if (delta == 0) {
+    global.classification = "Par";
+} else if (delta == 1) {
+    global.classification = "Bogey";
+} else {
+    global.classification = string(delta) + " over";
+}
+
 if (room_next(room) != -1) {
     room_goto_next();
 } else {
+    var idx = array_length(global.loaded_data.attempts) + 1;
+    var entry = { name: "attempt " + string(idx), score: global.running_total };
+    array_push(global.loaded_data.attempts, entry);
+    save_game(global.save_filename, global.loaded_data);
+    global.running_total = 0;
+    global.hole_scores = [];
     room_goto(rm_main_menu);
 }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -21,6 +21,20 @@ if (!variable_global_exists("controller")) {
 // ————————————————
 filename    = "slot1.json";
 loaded_data = load_game(filename);
+global.loaded_data = loaded_data;
+global.save_filename = filename;
+
+// Mapping of rooms to their par values
+par_values = {
+    rm_1: 3
+};
+
+// Initialise score tracking globals
+global.current_par   = 0;
+global.strokes       = 0;
+global.running_total = 0;
+global.hole_scores   = [];
+global.classification = "";
 
 // ————————————————
 // 3) Initialize Runtime Settings

--- a/objects/obj_controller/Draw_0.gml
+++ b/objects/obj_controller/Draw_0.gml
@@ -36,10 +36,10 @@ if (global.can_spawn_ball) {
 
 // Show attempt history on the main menu
 if (room == rm_main_menu && is_struct(global.loaded_data) && variable_struct_exists(global.loaded_data, "attempts")) {
-    var y = 96;
+    var y_pos = 96;
     for (var i = 0; i < array_length(global.loaded_data.attempts); i++) {
         var entry = global.loaded_data.attempts[i];
-        draw_text(48, y, entry.name + ": " + string(entry.score));
-        y += 20;
+        draw_text(48, y_pos, entry.name + ": " + string(entry.score));
+        y_pos += 20;
     }
 }

--- a/objects/obj_controller/Draw_0.gml
+++ b/objects/obj_controller/Draw_0.gml
@@ -25,3 +25,21 @@ if (is_struct(loaded_data)) {
 // Autosave countdown
 var time_left = max(0, AUTOSAVE_INTERVAL - autosave_timer);
 draw_text(48, 56, "Next Autosave In: " + string(round(time_left)) + "s");
+
+// Display current strokes and par during gameplay
+if (global.can_spawn_ball) {
+    draw_text(48, 76, "Strokes: " + string(global.strokes) + " / Par: " + string(global.current_par));
+    if (global.classification != "") {
+        draw_text(48, 96, global.classification);
+    }
+}
+
+// Show attempt history on the main menu
+if (room == rm_main_menu && is_struct(global.loaded_data) && variable_struct_exists(global.loaded_data, "attempts")) {
+    var y = 96;
+    for (var i = 0; i < array_length(global.loaded_data.attempts); i++) {
+        var entry = global.loaded_data.attempts[i];
+        draw_text(48, y, entry.name + ": " + string(entry.score));
+        y += 20;
+    }
+}

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -2,7 +2,12 @@
 
 // Reset spawn permission on room changes
 if (room != last_room) {
-    global.current_par = variable_struct_get(par_values, room_get_name(room), 0);
+    var room_name = room_get_name(room);
+    if (variable_struct_exists(par_values, room_name)) {
+        global.current_par = variable_struct_get(par_values, room_name);
+    } else {
+        global.current_par = 0;
+    }
     global.strokes = 0;
     global.classification = "";
     global.can_spawn_ball = (room != rm_main_menu && room != rm_options);

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -2,6 +2,9 @@
 
 // Reset spawn permission on room changes
 if (room != last_room) {
+    global.current_par = variable_struct_get(par_values, room_get_name(room), 0);
+    global.strokes = 0;
+    global.classification = "";
     global.can_spawn_ball = (room != rm_main_menu && room != rm_options);
     if (global.can_spawn_ball) {
         // Delay initial spawning to avoid accidental drops on room entry

--- a/objects/obj_gamepad/Step_0.gml
+++ b/objects/obj_gamepad/Step_0.gml
@@ -4,5 +4,6 @@ if (global.can_spawn_ball &&
     mouse_y < global.spawn_zone_height &&
     alarm[0] < 0) {
     instance_create_layer(mouse_x, mouse_y, layer, obj_ball);
+    global.strokes++;
     alarm[0] = 5;
 }

--- a/scripts/globals/globals.gml
+++ b/scripts/globals/globals.gml
@@ -1,3 +1,3 @@
-#macro SAVE_VERSION 2
+#macro SAVE_VERSION 3
 #macro SAVE_KEY "MySecretKey123"
 #macro AUTOSAVE_INTERVAL 10

--- a/scripts/load_game/load_game.gml
+++ b/scripts/load_game/load_game.gml
@@ -36,6 +36,9 @@ function load_game(_filename) {
             show_debug_message("[Save Upgrade] Version updated from " + string(original_version) + " to " + string(upgraded_data.version));
             save_game(_filename, upgraded_data);
         }
+        if (!variable_struct_exists(upgraded_data, "attempts")) {
+            upgraded_data.attempts = [];
+        }
 
         show_debug_message("END_LOAD_DATA");
         return upgraded_data;
@@ -47,7 +50,8 @@ function load_game(_filename) {
     var new_data = {
         version: SAVE_VERSION,
         sfx_enabled: true,
-		music_enabled: true
+        music_enabled: true,
+        attempts: []
     };
 
     save_game(_filename, new_data);

--- a/scripts/upgrade_save/upgrade_save.gml
+++ b/scripts/upgrade_save/upgrade_save.gml
@@ -4,7 +4,7 @@ function upgrade_save(_data) {
     switch (_data.version) {
         case 1:
             show_debug_message("[Save Upgrade] Upgrading from v1 to v2");
-			
+
             if (!variable_struct_exists(_data, "inventory")) {
                 show_debug_message("[Save Upgrade] Added missing 'inventory' field");
                 _data.inventory = [];
@@ -13,16 +13,24 @@ function upgrade_save(_data) {
             }
 
             _data.version = 2;
+            // fallthrough to apply further upgrades
+        case 2:
+            show_debug_message("[Save Upgrade] Upgrading from v2 to v3");
+            if (!variable_struct_exists(_data, "sfx_enabled")) {
+                _data.sfx_enabled = true;
+            }
+            if (!variable_struct_exists(_data, "music_enabled")) {
+                _data.music_enabled = true;
+            }
+            if (!variable_struct_exists(_data, "attempts")) {
+                _data.attempts = [];
+            }
+            _data.version = 3;
             break;
-		case 2: 
-			if (!variable_struct_exists(_data, "sfx_enabled")) {
-			  _data.sfx_enabled = true;
-				}
-			if (!variable_struct_exists(_data, "music_enabled")) {
-				_data.music_enabled = true;
-				}
-
         default:
+            if (!variable_struct_exists(_data, "attempts")) {
+                _data.attempts = [];
+            }
             show_debug_message("[Save Upgrade] No upgrade needed for version " + string(_data.version));
             break;
     }


### PR DESCRIPTION
## Summary
- map rooms to par values and initialize stroke tracking
- record scores on goal collision and log attempts
- display current strokes, par, and past attempt scores

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0a1f4f30832295ed7761f2e108c6