### PR TITLE
Add net animation to goal

### DIFF
--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -6,6 +6,9 @@ if (sfx_enabled) {
     audio_play_sound(phaser, 10, false);
 }
 
+// Trigger net animation on the goal
+other.net_offset = 6;
+
 global.can_spawn_ball = false;
 array_push(global.hole_scores, global.strokes);
 array_push(global.hole_pars, global.current_par);

--- a/objects/obj_goal/Create_0.gml
+++ b/objects/obj_goal/Create_0.gml
@@ -1,0 +1,2 @@
+// Initialize net animation offset
+net_offset = 0;

--- a/objects/obj_goal/Draw_0.gml
+++ b/objects/obj_goal/Draw_0.gml
@@ -1,0 +1,18 @@
+// Draw goal and white net that moves when hit
+var prev_col = draw_get_color();
+
+draw_self();
+
+draw_set_color(c_white);
+var top = y + sprite_get_height(sprite_index) / 2;
+var height = 20;
+var bottom = top + height;
+
+for (var i = -10; i <= 10; i += 5) {
+    draw_line(x + i, top, x + i, bottom + net_offset);
+}
+for (var j = 0; j <= height; j += 5) {
+    var y_line = top + j + net_offset * (j / height);
+    draw_line(x - 10, y_line, x + 10, y_line);
+}
+draw_set_color(prev_col);

--- a/objects/obj_goal/Step_0.gml
+++ b/objects/obj_goal/Step_0.gml
@@ -1,0 +1,2 @@
+// Gradually return net to rest position
+net_offset = lerp(net_offset, 0, 0.1);

--- a/objects/obj_goal/obj_goal.yy
+++ b/objects/obj_goal/obj_goal.yy
@@ -1,7 +1,11 @@
 {
   "$GMObject":"",
   "%Name":"obj_goal",
-  "eventList":[],
+  "eventList":[
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",}
+  ],
   "managed":true,
   "name":"obj_goal",
   "overriddenProperties":[],


### PR DESCRIPTION
## Summary
- draw a white net under the goal and animate it
- trigger net animation when the ball collides with the goal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2392753083229ae125307cc95f8a