### PR TITLE
Delay score screen transition for goal sound

### DIFF
--- a/objects/obj_ball/Alarm_0.gml
+++ b/objects/obj_ball/Alarm_0.gml
@@ -1,0 +1,1 @@
+room_goto(rm_score);

--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -25,5 +25,10 @@ if (delta <= -2) {
 
 
 global.next_room = room_next(room);
-room_goto(rm_score);
+if (sfx_enabled) {
+    var delay = max(1, ceil(audio_get_sound_length(swish_1) * room_speed));
+    alarm[0] = delay;
+} else {
+    room_goto(rm_score);
+}
 

--- a/objects/obj_ball/obj_ball.yy
+++ b/objects/obj_ball/obj_ball.yy
@@ -8,6 +8,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_floor","path":"objects/obj_floor/obj_floor.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_pin","path":"objects/obj_pin/obj_pin.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":1,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,


### PR DESCRIPTION
## Summary
- Delay room transition after scoring so goal swish sound can play
- Added alarm event on ball object to trigger score screen after delay

## Testing
- `rg -n 'alarm\[0\]' objects/obj_ball`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7c0fab08322870ce9655badb90c