### PR TITLE
Add debug toggle for autosave and audio UI

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -78,5 +78,8 @@ last_room = room;
 
 
 // List every Sound asset name GameMaker knows about
-global.bounce_snds = [ bounce_1, bounce_2, bounce_3, bounce_4 ]; 
+global.bounce_snds = [ bounce_1, bounce_2, bounce_3, bounce_4 ];
 global.swish_snds  = [ swish_1 ];
+
+// Debug flag to toggle drawing of autosave and audio settings
+show_debug_info = false;

--- a/objects/obj_controller/Draw_0.gml
+++ b/objects/obj_controller/Draw_0.gml
@@ -14,17 +14,18 @@ if (global.can_spawn_ball) {
     draw_set_color(c_white);
 }
 
-if (is_struct(loaded_data)) {
-    draw_text(48, 16, "SFX:   " + string(loaded_data.sfx_enabled ? "ON" : "OFF"));
-    draw_text(48, 36, "Music: " + string(loaded_data.music_enabled ? "ON" : "OFF"));
-} else {
-    draw_text(48, 16, "Save data not loaded.");
+if (show_debug_info) {
+    if (is_struct(loaded_data)) {
+        draw_text(48, 16, "SFX:   " + string(loaded_data.sfx_enabled ? "ON" : "OFF"));
+        draw_text(48, 36, "Music: " + string(loaded_data.music_enabled ? "ON" : "OFF"));
+    } else {
+        draw_text(48, 16, "Save data not loaded.");
+    }
+
+    // Autosave countdown
+    var time_left = max(0, AUTOSAVE_INTERVAL - autosave_timer);
+    draw_text(48, 56, "Next Autosave In: " + string(round(time_left)) + "s");
 }
-
-
-// Autosave countdown
-var time_left = max(0, AUTOSAVE_INTERVAL - autosave_timer);
-draw_text(48, 56, "Next Autosave In: " + string(round(time_left)) + "s");
 
 // Display current strokes and par during gameplay
 if (global.can_spawn_ball) {


### PR DESCRIPTION
## Summary
- gate autosave countdown and audio setting display behind `show_debug_info`
- add `show_debug_info` flag in controller creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ae8681dc832292c5340826b31108