### PR TITLE
Fix next room mapping and reorder level sequence

### DIFF
--- a/Basketball Drop.yyp
+++ b/Basketball Drop.yyp
@@ -97,9 +97,9 @@
     {"roomId":{"name":"rm_options","path":"rooms/rm_options/rm_options.yy",},},
     {"roomId":{"name":"rm_1","path":"rooms/rm_1/rm_1.yy",},},
     {"roomId":{"name":"rm_2","path":"rooms/rm_2/rm_2.yy",},},
+    {"roomId":{"name":"rm_3","path":"rooms/rm_3/rm_3.yy",},},
     {"roomId":{"name":"rm_score","path":"rooms/rm_score/rm_score.yy",},},
     {"roomId":{"name":"rm_parent","path":"rooms/rm_parent/rm_parent.yy",},},
-    {"roomId":{"name":"rm_3","path":"rooms/rm_3/rm_3.yy",},},
   ],
   "templateType":"game",
   "TextureGroups":[

--- a/objects/obj_ball/Collision_obj_goal.gml
+++ b/objects/obj_ball/Collision_obj_goal.gml
@@ -23,7 +23,12 @@ if (delta <= -2) {
     global.classification = string(delta) + " over";
 }
 
+var next_rooms = {
+    rm_1: rm_2,
+    rm_2: rm_3,
+};
 
-global.next_room = room_next(room);
+var current_room_name = room_get_name(room);
+global.next_room = variable_struct_get(next_rooms, current_room_name, -1);
 room_goto(rm_score);
 

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -9,9 +9,9 @@ if (room != last_room) {
         global.current_par = 0;
     }
     global.strokes = 0;
-    global.classification = "";
     global.can_spawn_ball = (room != rm_main_menu && room != rm_options && room != rm_score);
     if (global.can_spawn_ball) {
+        global.classification = "";
         global.par_total += global.current_par;
         // Delay initial spawning to avoid accidental drops on room entry
         global.spawn_ball_cooldown = 10;

--- a/objects/obj_scoreboard/Draw_0.gml
+++ b/objects/obj_scoreboard/Draw_0.gml
@@ -7,6 +7,13 @@ if (global.next_room == -1) {
     draw_text(room_width / 2, 32, "Final Scores");
 }
 
+// Show classification for the most recently completed hole
+var hole_index = array_length(global.hole_scores);
+if (hole_index > 0 && global.classification != "") {
+    draw_set_halign(fa_center);
+    draw_text(room_width / 2, 64, "Hole " + string(hole_index) + ": " + global.classification);
+}
+
 // table layout
 var cols = 4;
 var col_w = 80;


### PR DESCRIPTION
## Summary
- Map playable levels explicitly so goals advance to the correct next room
- Reorder RoomOrderNodes so playable rooms appear consecutively before non-playable ones

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python - <<'PY'
next_rooms = {'rm_1': 'rm_2', 'rm_2': 'rm_3'}
print('rm_2 ->', next_rooms.get('rm_2', -1))
print('rm_3 ->', next_rooms.get('rm_3', -1))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1b6bdaa08832282a5154c1826ed3e